### PR TITLE
Add Grand-Cypher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A curated list of resources for the Cypher and the openCypher graph query langua
 * [Cypher for Apache Spark (CAPS)](https://github.com/opencypher/cypher-for-apache-spark): run Cypher queries on Spark
 * [Cypher for Gremlin](https://github.com/opencypher/cypher-for-gremlin): run Cypher queries on Gremlin-compatible databases
 * [Gradoop](https://github.com/dbs-leipzig/gradoop): a distributed dataflow system for graph analytics and querying
+* [Grand-Cypher](https://github.com/aplbrain/grand-cypher/): run Cypher queries on NetworkX objects or sqlite databases in Python
 * [Graphflow](http://graphflow.io/): an active graph database
 * [ingraph](https://github.com/FTSRG/ingraph): an incremental openCypher engine
 * [Neo4j](https://github.com/neo4j/neo4j): the original Cypher graph database


### PR DESCRIPTION
This PR adds Grand-Cypher, an implementation of Cypher that runs on plain Python networkx objects (or other datatypes supported by [Grand](https://github.com/aplbrain/grand)).