### PR TITLE
Add ArcadeDB as Cypher-compatible database

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of resources for the Cypher and the openCypher graph query langua
 ## Query engines
 
 * [AgensGraph](https://github.com/bitnine-oss/agensgraph): a transactional graph database based on PostgreSQL
+* [ArcadeDB](https://github.com/ArcadeData/arcadedb): open-source multi-model database with TCK-compliant OpenCypher support, plus SQL and Gremlin. Apache 2.0 license
 * [Cypher for Apache Spark (CAPS)](https://github.com/opencypher/cypher-for-apache-spark): run Cypher queries on Spark
 * [Cypher for Gremlin](https://github.com/opencypher/cypher-for-gremlin): run Cypher queries on Gremlin-compatible databases
 * [Gradoop](https://github.com/dbs-leipzig/gradoop): a distributed dataflow system for graph analytics and querying


### PR DESCRIPTION
ArcadeDB is an open-source (Apache 2.0) multi-model database with TCK-compliant OpenCypher support. It also supports SQL and Gremlin query languages.

- GitHub: https://github.com/ArcadeData/arcadedb
- Website: https://arcadedb.com
- Cypher compliance: TCK-compliant via OpenCypher